### PR TITLE
do not raise exception on 404

### DIFF
--- a/artifactory_cleanup/rules/base.py
+++ b/artifactory_cleanup/rules/base.py
@@ -1,3 +1,4 @@
+import requests
 import inspect
 import json
 import re
@@ -198,10 +199,17 @@ class CleanupPolicy(object):
     def delete(self, artifact, destroy):
         artifact_path = "{repo}/{path}/{name}".format(**artifact)
         if destroy:
-            print("DESTROY MODE - delete {}".format(artifact_path))
             delete_url = "{}/{}".format(self.artifactory_url, artifact_path)
-            r = self.artifactory_session.delete(delete_url)
-            r.raise_for_status()
+            try:
+                r = self.artifactory_session.delete(delete_url)
+                r.raise_for_status()
+                print("DESTROY MODE - delete {}".format(artifact_path))
+            except requests.exceptions.HTTPError as e:
+                status_code = e.response.status_code
+                if status_code == 404:
+                    print("DESTROY MODE - artifact not found {}".format(artifact_path))
+                else:
+                    raise
         else:
             print("DEBUG - delete {}".format(artifact_path))
 


### PR DESCRIPTION
I saw a few cases where artifacts would disappear, however filter was convinced they existed.