### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3-alpine
+
+#RUN python -mpip install artifactory-cleanup && rm -rf ~/.cache
+
+ADD . /app
+WORKDIR /app
+RUN python setup.py install
+ENTRYPOINT [ "artifactory-cleanup" ]
+CMD [ "--help" ]


### PR DESCRIPTION
This one was not quite as simple, as noted elsewhere (#15), this is not `pip install`(able). 

This "works" but should probably be switched to a more release friendly version. Right now `--version` reports version is not set.

```bash
$ docker run devopshq/artifactory-cleanup --version
artifactory-cleanup (version not set)
```