### PR TITLE
Optimised fn: _collect_docker_size

### DIFF
--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -39,9 +39,13 @@ class RuleForDocker(Rule):
             args = ['items.find', {"$or": [{"repo": repo} for repo in docker_repos]}]
             artifacts_list = aql.aql(*args)
 
+            images_dict = defaultdict(int)
+            for docker_layer in artifacts_list:
+                images_dict[docker_layer['path']] += docker_layer['size']
+
             for artifact in new_result:
-                artifact['size'] = sum([docker_layer['size'] for docker_layer in artifacts_list if
-                                        docker_layer['path'] == '{}/{}'.format(artifact['path'], artifact['name'])])
+                image = f"{artifact['path']}/{artifact['name']}"
+                artifact['size'] = images_dict[image]
 
     def filter_result(self, result_artifacts):
         """ Determines the size of deleted images """


### PR DESCRIPTION
This PR fixes the issue [#18](https://github.com/devopshq/artifactory-cleanup/issues/18) by reducing the time complexity of `_collect_docker_size` function from O(n^2) to O(n) + O(n).