### PR TITLE
feat(ci): introduce GH workflow for releasing artifactory-cleanup.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@allburov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+---
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run on push on main branch
+        run: |
+          echo "Hello artifactory-cleanup on main!"
+      - name: Run on push on pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Hello artifactory-cleanup in pull request!"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+---
+name: Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.4.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+---
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    branches:
+      - master
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Generate GitHub token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
+        with:
+          application_id: ${{ secrets.SEMANTIC_RELEASE_APPLICATION_ID }}
+          application_private_key: ${{ secrets.SEMANTIC_RELEASE_APPLICATION_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ steps.get_workflow_token.outputs.token }}
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          semantic_version: 18.0.0
+          extra_plugins: |
+            @google/semantic-release-replace-plugin@1.1.0
+            @semantic-release/changelog@6.0.0
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Version released
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo ${{ steps.semantic.outputs.new_release_version }}
+          echo ${{ steps.semantic.outputs.new_release_major_version }}
+          echo ${{ steps.semantic.outputs.new_release_minor_version }}
+          echo ${{ steps.semantic.outputs.new_release_patch_version }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,51 @@
+{
+    "debug": true,
+    "branch": "master",
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "master",
+      "next"
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        [
+          "@google/semantic-release-replace-plugin",
+          {
+            "replacements": [{
+              "files": [
+                "setup.py"
+              ],
+              "from": "version=\".*\"",
+              "to": "version=\"${nextRelease.version}\"",
+              "results": [{
+                "file": "setup.py",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }],
+              "countMatches": true
+            }]
+          }
+        ],
+        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/changelog",
+            {
+                "changelogFile": "CHANGELOG.md",
+                "changelogTitle": "# Changelog"
+            }
+        ],
+        [
+          "@semantic-release/github",
+          {
+              "assets": "CHANGELOG.md"
+          }
+        ],
+        [
+          "@semantic-release/git", {
+            "assets": ["setup.py", "CHANGELOG.md"]
+          }
+        ]
+    ]
+}


### PR DESCRIPTION
The release process is based on conventional commits and will increment the semantic version and create a changelog automatically  based on conventional commit specs. (see http://conventionalcommits.org).

After a PR gets merged to main/master and the semantic-release toolchain determines the next version it will update the changelog, create a new tag and release. Apart from that it will as well reply to the PR and tell in which version the PR was released and add as well a link to it.

My idea was to have this as a first step and continue later with publishing this fantastic tool to pypi.org.

Let me know what you think about this.