### PR TITLE
fix check of ARTIFACTORY_DESTROY_MODE_ENABLED in docker image

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -33,7 +33,7 @@ fi
 cd $( dirname $ARTIFACTORY_RULES_CONFIG)
 
 DESTROY=""
-if [[ -v "$ARTIFACTORY_DESTROY_MODE_ENABLED" ]]; then
+if [[ -v ARTIFACTORY_DESTROY_MODE_ENABLED ]]; then
     DESTROY="--destroy"
 fi
 


### PR DESCRIPTION
There's a small bug in the Dockerfile regarding the check of the ARTIFACTORY_DESTROY_MODE_ENABLED variable.

As an implication of the bug the docker image can not be used to run in destroy mode.