### PR TITLE
Adding Docker image tags from Git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - "v*"
+      - "*"
   pull_request:
     branches:
       - 'master'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
   deploy-docker:
     runs-on: ubuntu-latest
 
-    if: ${{ always() }}
     needs: deploy-pypi
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
   deploy-docker:
     runs-on: ubuntu-latest
 
+    if: ${{ always() }}
     needs: deploy-pypi
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
 
-      - name: Login to DockerHub
+      - name: Login to image repository
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DEVOPSHQ_DOCKER_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   deploy-pypi:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          file: docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   deploy-pypi:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
 
     steps:
       - uses: actions/checkout@v2
@@ -31,6 +30,7 @@ jobs:
         run: python -m build
 
       - name: Publish package
+        if: github.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__
@@ -67,6 +67,6 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   deploy-pypi:
@@ -37,13 +42,28 @@ jobs:
     needs: deploy-pypi
     steps:
       - uses: actions/checkout@v2
-      - name: Login
-        env:
-          DOCKER_USER: ${{secrets.DEVOPSHQ_DOCKER_USER}}
-          DOCKER_PASSWORD: ${{secrets.DEVOPSHQ_DOCKER_TOKEN}}
-        run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - name: Build
-        run: docker build . --file docker/Dockerfile --tag devopshq/artifactory-cleanup:latest
-      - name: Push
-        run: docker push devopshq/artifactory-cleanup:latest
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: devopshq/artifactory-cleanup
+          flavor: latest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DEVOPSHQ_DOCKER_USER }}
+          password: ${{ secrets.DEVOPSHQ_DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Available Rules](#available-rules)
   - [Artifact cleanup policies](#artifact-cleanup-policies)
   - [Docker Container Usage](#docker-container-usage)
+- [Release](#release)
   
 <!-- tocstop -->
 
@@ -151,3 +152,9 @@ To build the container image locally run the following command in the folder of 
 docker build . --tag artifactory-cleanup
 ```
 
+# Release
+
+In order to provide a new release of `artifactory-cleanup`, there are two steps involved.
+
+1. Bump the version in the [setup.py](setup.py)
+2. Create a Git release tag (e.g. `v0.3.3`) by creating a release on Github


### PR DESCRIPTION
I've adjusted the Github action manifest in order to use Git tags / releases also as Docker image tags when pushing it to the image repository. Therefore, the `latest` tag will always be set. I presumed, that you might start creating releases on your Github repository. This will now lead the action to get triggered when a tag with the prefix `v*` is getting created. 

For instance, a Git tag `v0.33` will lead to the Docker image tag `0.33` and `latest`. When a PR is created, the action will also get triggered. I prevented pushing to pypa and pushing the Docker image though on a PR. The build step should be done.

I couldn't test this end to end since I haven't access to your registries, so I ask you to test this on your actual repo. I hope you find the additions useful and that all is fine despite the minimalistic testing I've done with my fork.

Philip