### PR TITLE
feat: add direct source code to clean up empty folders instead of depending on additional plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-## Upcoming Release
-
-### Major changes
+## 0.4.0
 
 - Remove `--remove-empty-folder` option. Artifactory provides corresponding built-in functionality already
 - Change the `delete_empty_folder` rule to not depend on an external plugin, but directly delete files from this script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Upcoming Release
+
+### Major changes
+
+- Remove `--remove-empty-folder` option. Artifactory provides corresponding built-in functionality already
+- Change the `delete_empty_folder` rule to not depend on an external plugin, but directly delete files from this script
+
+## 0.3.4
+
+* Previous versions do not yet have a changelog

--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ artifactory-cleanup --destroy --user user --password password --artifactory-serv
 # debug run - only print founded artifacts. it do not delete
 artifactory-cleanup --user user --password password --artifactory-server https://repo.example.com/artifactory --config reponame.py
 
-# Clean up empty folder
-# --remove-empty-folder
-# You need to use the plugin https://github.com/jfrog/artifactory-user-plugins/tree/master/cleanup/deleteEmptyDirs to delete empty folders
-artifactory-cleanup --remove-empty-folder --user user --password password --artifactory-server https://repo.example.com/artifactory
-
 # Debug run only for ruletestname. Find any *ruletestname*
 # debug run - only print founded artifacts. it do not delete
 artifactory-cleanup --rule-name ruletestname --user user --password password --artifactory-server https://repo.example.com/artifactory --config reponame.py

--- a/artifactory_cleanup/artifactorycleanup.py
+++ b/artifactory_cleanup/artifactorycleanup.py
@@ -10,7 +10,6 @@ from prettytable import PrettyTable
 from requests.auth import HTTPBasicAuth
 from artifactory_cleanup.context_managers import get_context_managers
 from artifactory_cleanup.rules.base import CleanupPolicy
-from artifactory_cleanup.rules.delete import delete_empty_folder
 
 
 requests.packages.urllib3.disable_warnings()

--- a/artifactory_cleanup/artifactorycleanup.py
+++ b/artifactory_cleanup/artifactorycleanup.py
@@ -61,10 +61,6 @@ class ArtifactoryCleanup(cli.Application):
         mandatory=False,
     )
 
-    _remove_empty_folder = cli.Flag(
-        "--remove-empty-folder", help="Cleaning up empty folders in local repositories"
-    )
-
     _days_in_future = cli.SwitchAttr(
         "--days-in-future",
         help="Simulate future behaviour",
@@ -83,21 +79,13 @@ class ArtifactoryCleanup(cli.Application):
     def main(self):
         # remove trailing slash
         self._artifactory_server = self._artifactory_server.rstrip("/")
-        if self._remove_empty_folder:
-            rules = [
-                CleanupPolicy(
-                    "Cleaning up empty folders in local repositories",
-                    delete_empty_folder(),
-                )
-            ]
-        else:
-            try:
-                self._config = self._config.replace(".py", "")
-                sys.path.append(".")
-                rules = getattr(importlib.import_module(self._config), "RULES")
-            except ImportError as error:
-                print("Error: {}".format(error))
-                exit(1)
+        try:
+            self._config = self._config.replace(".py", "")
+            sys.path.append(".")
+            rules = getattr(importlib.import_module(self._config), "RULES")
+        except ImportError as error:
+            print("Error: {}".format(error))
+            exit(1)
 
         self._destroy_or_verbose()
 

--- a/artifactory_cleanup/rules/delete.py
+++ b/artifactory_cleanup/rules/delete.py
@@ -135,8 +135,8 @@ class delete_empty_folder(Rule):
 
         # Artifactory also returns the directory itself. We need to remove it from the list
         # since that tree branch has no children assigned
-        if '.' in artifact_tree:
-            del artifact_tree['.']
+        if "." in artifact_tree:
+            del artifact_tree["."]
 
         # Now we have a dict with all folders and files
         # An empty folder is represented if it is a dict and does not have any keys

--- a/artifactory_cleanup/rules/delete.py
+++ b/artifactory_cleanup/rules/delete.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
-from collections import defaultdict, deque
 
 from artifactory_cleanup.rules.base import Rule
-from artifactory_cleanup.rules.utils import artifacts_list_to_tree, \
-    folder_artifacts_without_children
+from artifactory_cleanup.rules.utils import (
+    artifacts_list_to_tree,
+    folder_artifacts_without_children,
+)
 
 
 class delete_older_than(Rule):

--- a/artifactory_cleanup/rules/delete.py
+++ b/artifactory_cleanup/rules/delete.py
@@ -94,12 +94,7 @@ class delete_empty_folder(Rule):
 
     def _aql_add_filter(self, aql_query_list):
         # Get list of all files and folders
-        all_files_dict = {
-            "path": {
-                "$match": "**"
-            },
-            "type": {"$eq": "any"}
-        }
+        all_files_dict = {"path": {"$match": "**"}, "type": {"$eq": "any"}}
         aql_query_list.append(all_files_dict)
         return aql_query_list
 
@@ -125,17 +120,15 @@ class delete_empty_folder(Rule):
         def get_path_dict(artifacts):
             new_path_dict = nested_dict()
             for artifact in artifacts:
-                parts = artifact["path"].split('/')
+                parts = artifact["path"].split("/")
                 if parts:
                     marcher = new_path_dict
                     for key in parts:
                         # We need the repo for the root level folders. They are not in the
                         # artifacts list
-                        marcher[key]['data'] = {
-                            "repo": artifact['repo']
-                        }
-                        marcher = marcher[key]['children']
-                    marcher[artifact["name"]]['data'] = artifact
+                        marcher[key]["data"] = {"repo": artifact["repo"]}
+                        marcher = marcher[key]["children"]
+                    marcher[artifact["name"]]["data"] = artifact
             return default_to_regular(new_path_dict)
 
         artifact_tree = get_path_dict(result_artifact)
@@ -148,28 +141,27 @@ class delete_empty_folder(Rule):
             empty_folder_artifacts = deque()
 
             def _add_to_del_list(key):
-                empty_folder_artifacts.append(item[key]['data'])
+                empty_folder_artifacts.append(item[key]["data"])
                 # Also delete the item from the children list to recursively delete folders
                 # upwards
                 del item[key]
 
-
             for x in list(item.keys()):
-                if 'type' in item[x]['data'] and item[x]['data']['type'] == "file":
+                if "type" in item[x]["data"] and item[x]["data"]["type"] == "file":
                     continue
-                if not 'path' in item[x]['data']:
+                if not "path" in item[x]["data"]:
                     # Set the path and name for root folders which were not explicitly in the
                     # artifacts list
-                    item[x]['data']["path"] = path
-                    item[x]['data']["name"] = x
-                if not 'children' in item[x] or len(item[x]['children']) == 0:
+                    item[x]["data"]["path"] = path
+                    item[x]["data"]["name"] = x
+                if not "children" in item[x] or len(item[x]["children"]) == 0:
                     # This an empty folder
                     _add_to_del_list(x)
                 else:
-                    artifacts = get_folder_artifacts_with_no_children(item[x]['children'],
-                                                                      path=path + "/" + x if
-                                                                      len(path) > 0 else x)
-                    if len(item[x]['children']) == 0:
+                    artifacts = get_folder_artifacts_with_no_children(
+                        item[x]["children"], path=path + "/" + x if len(path) > 0 else x
+                    )
+                    if len(item[x]["children"]) == 0:
                         # just delete the whole folder since all children are empty
                         _add_to_del_list(x)
                     else:

--- a/artifactory_cleanup/rules/delete.py
+++ b/artifactory_cleanup/rules/delete.py
@@ -133,6 +133,11 @@ class delete_empty_folder(Rule):
 
         artifact_tree = get_path_dict(result_artifact)
 
+        # Artifactory also returns the directory itself. We need to remove it from the list
+        # since that tree branch has no children assigned
+        if '.' in artifact_tree:
+            del artifact_tree['.']
+
         # Now we have a dict with all folders and files
         # An empty folder is represented if it is a dict and does not have any keys
 

--- a/artifactory_cleanup/rules/utils.py
+++ b/artifactory_cleanup/rules/utils.py
@@ -40,8 +40,8 @@ def artifacts_list_to_tree(list_of_artifacts: List):
     artifact_tree = default_to_regular(new_path_dict)
     # Artifactory also returns the directory itself. We need to remove it from the list
     # since that tree branch has no children assigned
-    if '.' in artifact_tree:
-        del artifact_tree['.']
+    if "." in artifact_tree:
+        del artifact_tree["."]
     return artifact_tree
 
 
@@ -85,7 +85,8 @@ def folder_artifacts_without_children(artifacts_tree: Dict, path=""):
             _add_to_del_list(artifact_name)
         else:
             artifacts = folder_artifacts_without_children(
-                tree_entry["children"], path=path + "/" + artifact_name if len(path) > 0 else artifact_name
+                tree_entry["children"],
+                path=path + "/" + artifact_name if len(path) > 0 else artifact_name,
             )
             # Additional check needed here because the recursive call may
             # delete additional children.

--- a/artifactory_cleanup/rules/utils.py
+++ b/artifactory_cleanup/rules/utils.py
@@ -1,0 +1,101 @@
+from collections import defaultdict, deque
+from typing import Dict, List
+
+
+def artifacts_list_to_tree(list_of_artifacts: List):
+    """
+    Convert a list of artifacts to a dict representing the directory tree.
+    Each entry name corresponds to the folder or file name. And has two subnodes 'children' and
+    'data'. 'children' is recursively again the list of files/folder within that folder.
+    'data' contains the artifact data returned by artifactory.
+
+    Major idea based on https://stackoverflow.com/a/58917078
+    """
+
+    def nested_dict():
+        """
+        Creates a default dictionary where each value is another default dictionary.
+        """
+        return defaultdict(nested_dict)
+
+    def default_to_regular(d):
+        """
+        Converts defaultdicts of defaultdicts to dict of dicts.
+        """
+        if isinstance(d, defaultdict):
+            d = {k: default_to_regular(v) for k, v in d.items()}
+        return d
+
+    new_path_dict = nested_dict()
+    for artifact in list_of_artifacts:
+        parts = artifact["path"].split("/")
+        if parts:
+            marcher = new_path_dict
+            for key in parts:
+                # We need the repo for the root level folders. They are not in the
+                # artifacts list
+                marcher[key]["data"] = {"repo": artifact["repo"]}
+                marcher = marcher[key]["children"]
+            marcher[artifact["name"]]["data"] = artifact
+    artifact_tree = default_to_regular(new_path_dict)
+    # Artifactory also returns the directory itself. We need to remove it from the list
+    # since that tree branch has no children assigned
+    if '.' in artifact_tree:
+        del artifact_tree['.']
+    return artifact_tree
+
+
+def folder_artifacts_without_children(artifacts_tree: Dict, path=""):
+    """
+    Takes the artifacts tree and returns the list of artifacts which are folders
+    and do not have any children.
+
+    If folder1 has only folder2 as a child, and folder2 is empty, the list only contains
+    folder1. I.e., empty folders are also recursively propagated back.
+
+    The input tree will be modified and empty folders will be deleted from the tree.
+
+    """
+
+    # use a deque instead of a list. it's faster to add elements there
+    empty_folder_artifacts = deque()
+
+    def _add_to_del_list(name: str):
+        """
+        Add element with name to empty folder list and remove it from the tree
+        """
+        empty_folder_artifacts.append(artifacts_tree[name]["data"])
+        # Also delete the item from the children list to recursively delete folders
+        # upwards
+        del artifacts_tree[name]
+
+    # Use list(item.keys()) here so that we can delete items while iterating over the
+    # dict.
+    for artifact_name in list(artifacts_tree.keys()):
+        tree_entry = artifacts_tree[artifact_name]
+        if "type" in tree_entry["data"] and tree_entry["data"]["type"] == "file":
+            continue
+        if not "path" in tree_entry["data"]:
+            # Set the path and name for root folders which were not explicitly in the
+            # artifacts list
+            tree_entry["data"]["path"] = path
+            tree_entry["data"]["name"] = artifact_name
+        if not "children" in tree_entry or len(tree_entry["children"]) == 0:
+            # This an empty folder
+            _add_to_del_list(artifact_name)
+        else:
+            artifacts = folder_artifacts_without_children(
+                tree_entry["children"], path=path + "/" + artifact_name if len(path) > 0 else artifact_name
+            )
+            # Additional check needed here because the recursive call may
+            # delete additional children.
+            # And here we want to check again if all children would be deleted.
+            # Then also delete this.
+            if len(tree_entry["children"]) == 0:
+                # just delete the whole folder since all children are empty
+                _add_to_del_list(artifact_name)
+            else:
+                # add all empty folder children to the list
+                empty_folder_artifacts.extend(artifacts)
+
+    return empty_folder_artifacts

--- a/docs/RULES/README.md
+++ b/docs/RULES/README.md
@@ -8,7 +8,7 @@
 | `delete_without_downloads()` | Deletes artifacts that have never been downloaded (DownloadCount=0). Better to use with `delete_older_than` rule |
 | `delete_older_than_n_days_without_downloads(days=N)` | Deletes artifacts that are older than N days and have not been downloaded |
 | `delete_not_used_since(days=N)` | Delete artifacts that were downloaded, but for a long time. N days passed. Or not downloaded at all from the moment of creation and it's been N days |
-| `delete_empty_folder()` | Clean up empty folders in local repositories. A special rule that runs separately on all repositories. Refers to [deleteEmptyDirs](https://github.com/jfrog/artifactory-user-plugins/tree/master/cleanup/deleteEmptyDirs) plugin |
+| `delete_empty_folder()` | Clean up empty folders in given repository list |
 | `keep_latest_nupkg_n_version(count=N)` | Leaves N nupkg (adds `*.nupkg` filter) in release feature builds |
 | `keep_latest_n_file(count=N)` | Leaves the last (by creation time) files in the amount of N pieces. WITHOUT accounting subfolders |
 | `keep_latest_n_file_in_folder(count=N)` | Leaves the last (by creation time) files in the number of N pieces in each folder |

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="artifactory-cleanup",
-    version="0.3.4",
+    version="0.4.0",
     description="Rules and cleanup policies for Artifactory",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/artifacts_list.json
+++ b/tests/artifacts_list.json
@@ -1,0 +1,467 @@
+[
+  {
+    "repo": "test-repo",
+    "path": ".",
+    "name": ".",
+    "type": "folder",
+    "size": 0,
+    "depth": 0
+  },
+  {
+    "repo": "test-repo",
+    "path": ".",
+    "name": "user1",
+    "type": "folder",
+    "size": 0,
+    "depth": 1
+  },
+  {
+    "repo": "test-repo",
+    "path": ".",
+    "name": "user2",
+    "type": "folder",
+    "size": 0,
+    "depth": 1
+  },
+  {
+    "repo": "test-repo",
+    "path": ".",
+    "name": "user3",
+    "type": "folder",
+    "size": 0,
+    "depth": 1
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1",
+    "name": "package1",
+    "type": "folder",
+    "size": 0,
+    "depth": 2
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1",
+    "name": "0.1.2",
+    "type": "folder",
+    "size": 0,
+    "depth": 3
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2",
+    "name": "testing",
+    "type": "folder",
+    "size": 0,
+    "depth": 4
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing",
+    "name": "ee9a7171a4577b0077ba521a2a16411f",
+    "type": "folder",
+    "size": 0,
+    "depth": 5
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing",
+    "name": "6a5ffb1868d640cbcb78c934c4728895",
+    "type": "folder",
+    "size": 0,
+    "depth": 5
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895",
+    "name": "export",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895",
+    "name": "package",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/export",
+    "name": "conanfile.py",
+    "type": "file",
+    "size": 896,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/export",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 58,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/package",
+    "name": "9bfdcfa2bb925892ecf42e2a018a3f3529826676",
+    "type": "folder",
+    "size": 0,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676",
+    "name": "53518c74f2e9410bb2f6df473adee01f",
+    "type": "folder",
+    "size": 0,
+    "depth": 8
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676/53518c74f2e9410bb2f6df473adee01f",
+    "name": "conan_package.tgz",
+    "type": "file",
+    "size": 171473,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676/53518c74f2e9410bb2f6df473adee01f",
+    "name": "conaninfo.txt",
+    "type": "file",
+    "size": 436,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676/53518c74f2e9410bb2f6df473adee01f",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 2197,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f",
+    "name": "export",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f",
+    "name": "package",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/export",
+    "name": "conanfile.py",
+    "type": "file",
+    "size": 904,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/export",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 58,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/package",
+    "name": "9bfdcfa2bb925892ecf42e2a018a3f3529826676",
+    "type": "folder",
+    "size": 0,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676",
+    "name": "bb158820ff3cdfb0764acd8abd0fcb05",
+    "type": "folder",
+    "size": 0,
+    "depth": 8
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676/bb158820ff3cdfb0764acd8abd0fcb05",
+    "name": "conan_package.tgz",
+    "type": "file",
+    "size": 171473,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676/bb158820ff3cdfb0764acd8abd0fcb05",
+    "name": "conaninfo.txt",
+    "type": "file",
+    "size": 436,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/ee9a7171a4577b0077ba521a2a16411f/package/9bfdcfa2bb925892ecf42e2a018a3f3529826676/bb158820ff3cdfb0764acd8abd0fcb05",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 2197,
+    "depth": 9
+  },
+
+  {
+    "repo": "test-repo",
+    "path": "user1/package1",
+    "name": "0.1.2",
+    "type": "folder",
+    "size": 0,
+    "depth": 3
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2",
+    "name": "testing",
+    "type": "folder",
+    "size": 0,
+    "depth": 4
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing",
+    "name": "ee9a7171a4577b0077ba521a2a16411f",
+    "type": "folder",
+    "size": 0,
+    "depth": 5
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing",
+    "name": "6a5ffb1868d640cbcb78c934c4728895",
+    "type": "folder",
+    "size": 0,
+    "depth": 5
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895",
+    "name": "export",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895",
+    "name": "package",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/export",
+    "name": "conanfile.py",
+    "type": "file",
+    "size": 896,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/export",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 58,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user1/package1/0.1.2/testing/6a5ffb1868d640cbcb78c934c4728895/package",
+    "name": "9bfdcfa2bb925892ecf42e2a018a3f3529826676",
+    "type": "folder",
+    "size": 0,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2",
+    "name": "package2",
+    "type": "folder",
+    "size": 0,
+    "depth": 2
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2",
+    "name": "package5",
+    "type": "folder",
+    "size": 0,
+    "depth": 2
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2",
+    "name": "4.2.0",
+    "type": "folder",
+    "size": 0,
+    "depth": 3
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2",
+    "name": "4.2.1",
+    "type": "folder",
+    "size": 0,
+    "depth": 3
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0",
+    "name": "testing",
+    "type": "folder",
+    "size": 0,
+    "depth": 4
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing",
+    "name": "18259fd357457eed2a5b2dffede67385",
+    "type": "folder",
+    "size": 0,
+    "depth": 5
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385",
+    "name": "export",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385",
+    "name": "package",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/export",
+    "name": "conanfile.py",
+    "type": "file",
+    "size": 4970,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/export",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 58,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/package",
+    "name": "976790fbda33f5619b11df9030fb714af0990694",
+    "type": "folder",
+    "size": 0,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/package/976790fbda33f5619b11df9030fb714af0990694",
+    "name": "8854919f6b53ccf1c347f5a34b475b6a",
+    "type": "folder",
+    "size": 0,
+    "depth": 8
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/package/976790fbda33f5619b11df9030fb714af0990694/8854919f6b53ccf1c347f5a34b475b6a",
+    "name": "conan_package.tgz",
+    "type": "file",
+    "size": 21835527,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/package/976790fbda33f5619b11df9030fb714af0990694/8854919f6b53ccf1c347f5a34b475b6a",
+    "name": "conaninfo.txt",
+    "type": "file",
+    "size": 2676,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user2/package2/4.2.0/testing/18259fd357457eed2a5b2dffede67385/package/976790fbda33f5619b11df9030fb714af0990694/8854919f6b53ccf1c347f5a34b475b6a",
+    "name": "conanmanifest.txt",
+    "type": "file",
+    "size": 67044,
+    "depth": 9
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1",
+    "name": "testing2",
+    "type": "folder",
+    "size": 0,
+    "depth": 4
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1/testing2",
+    "name": "18259fd357457eed2a5b2dffede67385",
+    "type": "folder",
+    "size": 0,
+    "depth": 5
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1/testing2/18259fd357457eed2a5b2dffede67385",
+    "name": "export",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1/testing2/18259fd357457eed2a5b2dffede67385",
+    "name": "package",
+    "type": "folder",
+    "size": 0,
+    "depth": 6
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1/testing2/18259fd357457eed2a5b2dffede67385/package",
+    "name": "976790fbda33f5619b11df9030fb714af0990694",
+    "type": "folder",
+    "size": 0,
+    "depth": 7
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1/testing2/18259fd357457eed2a5b2dffede67385/package/976790fbda33f5619b11df9030fb714af0990694",
+    "name": "e708164fb64d5cce0bef0354b59a17ac",
+    "type": "folder",
+    "size": 0,
+    "depth": 8
+  },
+  {
+    "repo": "test-repo",
+    "path": "user3/package3/4.2.1/testing2/18259fd357457eed2a5b2dffede67385/package/976790fbda33f5619b11df9030fb714af0990694",
+    "name": "ba38761e49a42a9a44c8be1e30df4886",
+    "type": "folder",
+    "size": 0,
+    "depth": 8
+  }
+]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import json
 
-from artifactory_cleanup.rules.utils import artifacts_list_to_tree, \
-    folder_artifacts_without_children
+from artifactory_cleanup.rules.utils import (
+    artifacts_list_to_tree,
+    folder_artifacts_without_children,
+)
 
 
 def test_artifacts_list_to_tree():
@@ -13,9 +15,12 @@ def test_artifacts_list_to_tree():
     # Just some rough testing to verify that tree is correctly built
     assert sorted(artifacts_tree.keys()) == sorted(["user1", "user2", "user3"])
     assert sorted(artifacts_tree["user1"]["children"].keys()) == sorted(["package1"])
-    assert sorted(artifacts_tree["user2"]["children"].keys()) == sorted(["package2", "package5"])
-    assert sorted(artifacts_tree["user2"]["children"]["package2"]["children"].keys()) == sorted([
-        "4.2.0", "4.2.1"])
+    assert sorted(artifacts_tree["user2"]["children"].keys()) == sorted(
+        ["package2", "package5"]
+    )
+    assert sorted(
+        artifacts_tree["user2"]["children"]["package2"]["children"].keys()
+    ) == sorted(["4.2.0", "4.2.1"])
     assert sorted(artifacts_tree["user3"]["children"].keys()) == sorted(["package3"])
 
 
@@ -35,12 +40,14 @@ def test_folder_artifacts_without_children():
         # Simple empty folder without children at a higher level
         "user2/package5",
         # Longer folder structure where all subfolders are empty
-        "user3"
+        "user3",
     ]
 
     for empty_folder in empty_folders:
-        empty_path = empty_folder['path'] + "/" + empty_folder['name'] if len(
-            empty_folder['path']) > 0 \
-            else empty_folder['name']
+        empty_path = (
+            empty_folder["path"] + "/" + empty_folder["name"]
+            if len(empty_folder["path"]) > 0
+            else empty_folder["name"]
+        )
 
         assert empty_path in expected_empty_folders

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+import json
+
+from artifactory_cleanup.rules.utils import artifacts_list_to_tree, \
+    folder_artifacts_without_children
+
+
+def test_artifacts_list_to_tree():
+    with open("artifacts_list.json", "r") as fp:
+        artifacts_list = json.load(fp)
+
+    artifacts_tree = artifacts_list_to_tree(artifacts_list)
+
+    # Just some rough testing to verify that tree is correctly built
+    assert sorted(artifacts_tree.keys()) == sorted(["user1", "user2", "user3"])
+    assert sorted(artifacts_tree["user1"]["children"].keys()) == sorted(["package1"])
+    assert sorted(artifacts_tree["user2"]["children"].keys()) == sorted(["package2", "package5"])
+    assert sorted(artifacts_tree["user2"]["children"]["package2"]["children"].keys()) == sorted([
+        "4.2.0", "4.2.1"])
+    assert sorted(artifacts_tree["user3"]["children"].keys()) == sorted(["package3"])
+
+
+def test_folder_artifacts_without_children():
+    with open("artifacts_list.json", "r") as fp:
+        artifacts_list = json.load(fp)
+
+    artifacts_tree = artifacts_list_to_tree(artifacts_list)
+
+    empty_folders = folder_artifacts_without_children(artifacts_tree)
+
+    assert len(empty_folders) == 3
+
+    expected_empty_folders = [
+        # Simple empty folder without children in the list, at a deeper level
+        "user2/package2/4.2.1",
+        # Simple empty folder without children at a higher level
+        "user2/package5",
+        # Longer folder structure where all subfolders are empty
+        "user3"
+    ]
+
+    for empty_folder in empty_folders:
+        empty_path = empty_folder['path'] + "/" + empty_folder['name'] if len(
+            empty_folder['path']) > 0 \
+            else empty_folder['name']
+
+        assert empty_path in expected_empty_folders


### PR DESCRIPTION
I added a bit more logic to the `delete_empty_folder()` rule to directly delete empty folders from the script, instead of depending on an additional plugin