### PR TITLE
fix:  KeepLatestVersionNFilesInFolder to return the artifact set properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ policies:
 ```
 
 - `KeepLatestVersionNFilesInFolder` - Leaves the latest N (by version) files in each
-  folder. The definition of the version is using regexp. By default `[^\d][\._]((\d+\.)+\d+)`
+  folder. The definition of the version is using regexp. By default it parses [semver](https://semver.org/) using the regex - `([\d]+\.[\d]+\.[\d]+)")`
 
 ```yaml
 - rule: KeepLatestVersionNFilesInFolder

--- a/artifactory_cleanup/rules/keep.py
+++ b/artifactory_cleanup/rules/keep.py
@@ -177,7 +177,13 @@ class KeepLatestVersionNFilesInFolder(Rule):
             if good_artifact_count < 0:
                 good_artifact_count = 0
 
-            good_artifacts = artifactory_with_version[good_artifact_count:]
+            good_sets = artifactory_with_version[good_artifact_count:]
+  
+            good_artifacts = []
+  
+            for good_set in good_sets:
+              good_artifacts.append(good_set[1])
+
             artifacts.keep(good_artifacts)
 
         return artifacts

--- a/artifactory_cleanup/rules/keep.py
+++ b/artifactory_cleanup/rules/keep.py
@@ -165,7 +165,11 @@ class KeepLatestVersionNFilesInFolder(Rule):
                 key = path + "/" + name_without_version
                 artifacts_by_path_and_name[key].append(artifactory_with_version)
             else:
-                print("Warning: Could not identify version for {}/{}".format(artifact["path"], artifact["name"]))
+                print(
+                    "Warning: Could not identify version for {}/{}".format(
+                        artifact["path"], artifact["name"]
+                    )
+                )
                 artifacts.keep(artifact)
 
         for artifactory_with_version in artifacts_by_path_and_name.values():
@@ -179,11 +183,11 @@ class KeepLatestVersionNFilesInFolder(Rule):
                 good_artifact_count = 0
 
             good_sets = artifactory_with_version[good_artifact_count:]
-  
+
             good_artifacts = []
-  
+
             for good_set in good_sets:
-              good_artifacts.append(good_set[1])
+                good_artifacts.append(good_set[1])
 
             artifacts.keep(good_artifacts)
 

--- a/artifactory_cleanup/rules/keep.py
+++ b/artifactory_cleanup/rules/keep.py
@@ -143,7 +143,7 @@ class KeepLatestVersionNFilesInFolder(Rule):
     The definition of the version is using regexp. By default ``r'[^ \d][[\._]]()((\d+\.)+\d+)')``
     """
 
-    def __init__(self, count, custom_regexp=r"[^\d][\._]((\d+\.)+\d+)"):
+    def __init__(self, count, custom_regexp=r"([\d]+\.[\d]+\.[\d]+)"):
         self.count = count
         self.custom_regexp = custom_regexp
 
@@ -165,6 +165,7 @@ class KeepLatestVersionNFilesInFolder(Rule):
                 key = path + "/" + name_without_version
                 artifacts_by_path_and_name[key].append(artifactory_with_version)
             else:
+                print("Warning: Could not identify version for {}/{}".format(artifact["path"], artifact["name"]))
                 artifacts.keep(artifact)
 
         for artifactory_with_version in artifacts_by_path_and_name.values():

--- a/artifactory_cleanup/rules/keep.py
+++ b/artifactory_cleanup/rules/keep.py
@@ -182,12 +182,10 @@ class KeepLatestVersionNFilesInFolder(Rule):
             if good_artifact_count < 0:
                 good_artifact_count = 0
 
+            # artifactory_with_version contains list of (Version, Artifact)  pairs
+            # Get the artifacts from that for return to 'keep'
             good_sets = artifactory_with_version[good_artifact_count:]
-
-            good_artifacts = []
-
-            for good_set in good_sets:
-                good_artifacts.append(good_set[1])
+            good_artifacts = [good[1] for good in good_sets]
 
             artifacts.keep(good_artifacts)
 

--- a/tests/test_rules_keep.py
+++ b/tests/test_rules_keep.py
@@ -91,6 +91,7 @@ def test_KeepLatestNFilesInFolder():
     ]
     assert makeas(remove_these, expected) == expected
 
+
 def test_KeepLatestVersionNFilesInFolderDefault():
     data = [
         {
@@ -128,6 +129,7 @@ def test_KeepLatestVersionNFilesInFolderDefault():
         {"name": "0.0.1.zip", "path": "folder2"},
     ]
     assert makeas(remove_these, expected) == expected
+
 
 def test_KeepLatestVersionNFilesInFolderRegexWork():
     data = [
@@ -170,13 +172,16 @@ def test_KeepLatestVersionNFilesInFolderRegexWork():
 
     artifacts = ArtifactsList.from_response(data)
 
-    remove_these = KeepLatestVersionNFilesInFolder(1, "[\\d]+\\.([\\d]+\\.[\\d]+)").filter(artifacts)
+    remove_these = KeepLatestVersionNFilesInFolder(
+        1, "[\\d]+\\.([\\d]+\\.[\\d]+)"
+    ).filter(artifacts)
     expected = [
         {"name": "0.0.1.zip", "path": "folder1"},
         {"name": "0.0.1.zip", "path": "folder2"},
         {"name": "1.0.1.zip", "path": "folder3"},
     ]
     assert makeas(remove_these, expected) == expected
+
 
 def test_KeepLatestVersionNFilesInFolderRegexFail():
     data = [
@@ -209,7 +214,8 @@ def test_KeepLatestVersionNFilesInFolderRegexFail():
 
     artifacts = ArtifactsList.from_response(data)
 
-    remove_these = KeepLatestVersionNFilesInFolder(1, "[^\\d][\\._]((\\d+\\.)+\\d+)").filter(artifacts)
-    expected = [
-    ]
+    remove_these = KeepLatestVersionNFilesInFolder(
+        1, "[^\\d][\\._]((\\d+\\.)+\\d+)"
+    ).filter(artifacts)
+    expected = []
     assert makeas(remove_these, expected) == expected

--- a/tests/test_rules_keep.py
+++ b/tests/test_rules_keep.py
@@ -2,6 +2,7 @@ from artifactory_cleanup.rules import (
     KeepLatestNFiles,
     ArtifactsList,
     KeepLatestNFilesInFolder,
+    KeepLatestVersionNFilesInFolder,
 )
 from tests.utils import makeas
 
@@ -87,5 +88,128 @@ def test_KeepLatestNFilesInFolder():
     expected = [
         {"name": "0.0.1.zip", "path": "folder1"},
         {"name": "0.0.1.zip", "path": "folder2"},
+    ]
+    assert makeas(remove_these, expected) == expected
+
+def test_KeepLatestVersionNFilesInFolderDefault():
+    data = [
+        {
+            "path": "folder1",
+            "name": "0.0.2.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder1",
+            "name": "0.0.1.zip",
+            "created": "2021-03-19T13:53:52.383+02:00",
+        },
+        {
+            "path": "folder2",
+            "name": "0.0.1.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder2",
+            "name": "0.0.2.zip",
+            "created": "2021-03-19T13:53:52.383+02:00",
+        },
+        {
+            "path": "folder3",
+            "name": "0.0.1.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+    ]
+
+    artifacts = ArtifactsList.from_response(data)
+
+    remove_these = KeepLatestVersionNFilesInFolder(1).filter(artifacts)
+    expected = [
+        {"name": "0.0.1.zip", "path": "folder1"},
+        {"name": "0.0.1.zip", "path": "folder2"},
+    ]
+    assert makeas(remove_these, expected) == expected
+
+def test_KeepLatestVersionNFilesInFolderRegexWork():
+    data = [
+        {
+            "path": "folder1",
+            "name": "0.0.2.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder1",
+            "name": "0.0.1.zip",
+            "created": "2021-03-19T13:53:52.383+02:00",
+        },
+        {
+            "path": "folder2",
+            "name": "0.0.1.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder2",
+            "name": "0.0.2.zip",
+            "created": "2021-03-19T13:53:52.383+02:00",
+        },
+        {
+            "path": "folder3",
+            "name": "0.0.1.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder3",
+            "name": "1.0.1.zip",
+            "created": "2021-03-21T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder3",
+            "name": "1.0.2.zip",
+            "created": "2021-03-21T14:54:52.383+02:00",
+        },
+    ]
+
+    artifacts = ArtifactsList.from_response(data)
+
+    remove_these = KeepLatestVersionNFilesInFolder(1, "[\\d]+\\.([\\d]+\\.[\\d]+)").filter(artifacts)
+    expected = [
+        {"name": "0.0.1.zip", "path": "folder1"},
+        {"name": "0.0.1.zip", "path": "folder2"},
+        {"name": "1.0.1.zip", "path": "folder3"},
+    ]
+    assert makeas(remove_these, expected) == expected
+
+def test_KeepLatestVersionNFilesInFolderRegexFail():
+    data = [
+        {
+            "path": "folder1",
+            "name": "0.0.2.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder1",
+            "name": "0.0.1.zip",
+            "created": "2021-03-19T13:53:52.383+02:00",
+        },
+        {
+            "path": "folder2",
+            "name": "0.0.1.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+        {
+            "path": "folder2",
+            "name": "0.0.2.zip",
+            "created": "2021-03-19T13:53:52.383+02:00",
+        },
+        {
+            "path": "folder3",
+            "name": "0.0.1.zip",
+            "created": "2021-03-20T13:54:52.383+02:00",
+        },
+    ]
+
+    artifacts = ArtifactsList.from_response(data)
+
+    remove_these = KeepLatestVersionNFilesInFolder(1, "[^\\d][\\._]((\\d+\\.)+\\d+)").filter(artifacts)
+    expected = [
     ]
     assert makeas(remove_these, expected) == expected


### PR DESCRIPTION
This is the fix for devopshq/artifactory-cleanup#80

Also updated the regex to pull out a semantic version, the original wasn't working to pull the version out of the strings. See tests for proof.

Also added a warning message when the version couldn't be identified.