### PR TITLE
Avoid crash on custom rules without doc string

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,11 @@ from artifactory_cleanup.rules import Rule, ArtifactsList
 
 
 class MySimpleRule(Rule):
-    """For more methods look at Rule source code"""
+    """
+    This doc string is used as rule title
+
+    For more methods look at Rule source code
+    """
 
     def __init__(self, my_param: str, value: int):
         self.my_param = my_param

--- a/artifactory_cleanup/rules/base.py
+++ b/artifactory_cleanup/rules/base.py
@@ -91,10 +91,9 @@ class Rule(object):
     @classmethod
     def title(cls) -> str:
         """Cut the docstring to show only the very first important line"""
-        if cls.__doc__:
-            return [x.strip() for x in cls.__doc__.splitlines() if x][0]
-        else:
+        if not cls.__doc__:
             return ""
+        return [x.strip() for x in cls.__doc__.splitlines() if x][0]
 
     def init(self, session, today, *args, **kwargs) -> None:
         """

--- a/artifactory_cleanup/rules/base.py
+++ b/artifactory_cleanup/rules/base.py
@@ -91,8 +91,10 @@ class Rule(object):
     @classmethod
     def title(cls) -> str:
         """Cut the docstring to show only the very first important line"""
-        docs = [x.strip() for x in cls.__doc__.splitlines() if x][0]
-        return docs
+        if cls.__doc__:
+            return [x.strip() for x in cls.__doc__.splitlines() if x][0]
+        else:
+            return ""
 
     def init(self, session, today, *args, **kwargs) -> None:
         """

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -1,0 +1,19 @@
+from artifactory_cleanup.rules import Rule
+
+
+class CustomRuleWithDocs(Rule):
+    """ Example with doc string """
+
+
+class CustomRuleWithoutDocs(Rule):
+    pass
+
+
+def test_custom_rule_with_docstring_adds_to_title():
+    rule = CustomRuleWithDocs()
+    assert rule.title() == "Example with doc string"
+
+
+def test_custom_rule_without_docstring():
+    rule = CustomRuleWithoutDocs()
+    assert rule.title() == ""

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -2,7 +2,7 @@ from artifactory_cleanup.rules import Rule
 
 
 class CustomRuleWithDocs(Rule):
-    """ Example with doc string """
+    """Example with doc string"""
 
 
 class CustomRuleWithoutDocs(Rule):


### PR DESCRIPTION
Custom rules without a doc string crash as `cls.__doc__` is `None`.