### PR TITLE
Include the path when grouping images for KeepLatestNVersionImagesByProperty

### DIFF
--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -229,7 +229,7 @@ class KeepLatestNVersionImagesByProperty(RuleForDocker):
 
         def _groupby(artifact):
             """Group by major/minor/patch version"""
-            return self.get_version(artifact)[: self.number_of_digits_in_version]
+            return (artifact["path"], self.get_version(artifact)[: self.number_of_digits_in_version]) 
 
         # Group artifacts by major/minor or patch
         grouped = pydash.group_by(artifacts, iteratee=_groupby)

--- a/tests/test_rules_docker.py
+++ b/tests/test_rules_docker.py
@@ -76,6 +76,12 @@ class TestKeepLatestNVersionImagesByProperty:
         )
         assert policy.filter(artifacts) == [
             {
+                "name": "0.1.83",
+                "path": "baz",
+                "properties": {"docker.manifest": "0.1.83"},
+                "stats": {},
+            },
+            {
                 "name": "0.1.99",
                 "path": "foobar",
                 "properties": {"docker.manifest": "0.1.99"},
@@ -85,12 +91,6 @@ class TestKeepLatestNVersionImagesByProperty:
                 "name": "1.1.1",
                 "path": "foobar",
                 "properties": {"docker.manifest": "1.1.1"},
-                "stats": {},
-            },
-            {
-                "name": "0.1.83",
-                "path": "baz",
-                "properties": {"docker.manifest": "0.1.83"},
                 "stats": {},
             },
         ]

--- a/tests/test_rules_docker.py
+++ b/tests/test_rules_docker.py
@@ -48,6 +48,21 @@ class TestKeepLatestNVersionImagesByProperty:
                 "path": "foobar/2.1.1",
                 "name": "manifest.json",
             },
+            {
+                "properties": {"docker.manifest": "0.1.86"},
+                "path": "baz/0.1.86",
+                "name": "manifest.json",
+            },
+            {
+                "properties": {"docker.manifest": "0.1.87"},
+                "path": "baz/0.1.87",
+                "name": "manifest.json",
+            },
+            {
+                "properties": {"docker.manifest": "0.1.83"},
+                "path": "baz/0.1.83",
+                "name": "manifest.json",
+            },
         ]
         artifacts = ArtifactsList.from_response(data)
         policy = CleanupPolicy(
@@ -70,6 +85,12 @@ class TestKeepLatestNVersionImagesByProperty:
                 "name": "1.1.1",
                 "path": "foobar",
                 "properties": {"docker.manifest": "1.1.1"},
+                "stats": {},
+            },
+            {
+                "name": "0.1.83",
+                "path": "baz",
+                "properties": {"docker.manifest": "0.1.83"},
                 "stats": {},
             },
         ]


### PR DESCRIPTION
This should fix https://github.com/devopshq/artifactory-cleanup/issues/77.

Before this change, image tags were only grouped by the versioning. This is okay if there is only one image specified but is not correct when multiple images are specified.

