### PR TITLE
Substitute repo name in yaml

### DIFF
--- a/artifactory_cleanup/__init__.py
+++ b/artifactory_cleanup/__init__.py
@@ -7,4 +7,4 @@ def register(rule):
     registry.register(rule)
 
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/artifactory_cleanup/rules/repo.py
+++ b/artifactory_cleanup/rules/repo.py
@@ -1,6 +1,6 @@
 from sys import stderr
 from typing import List
-
+import os
 from requests import HTTPError
 
 from artifactory_cleanup.errors import InvalidConfigError
@@ -15,7 +15,13 @@ class Repo(Rule):
     schema = []
 
     def __init__(self, name: str):
+        """
+        Checks if the name of the repo starts with an $, indicating a variable. substitutes with the variable if it exists.
+        otherwise assume that the $ is part of the repo name
+        """
         bad_sym = set("*/[]")
+        if name.startswith("$") & (os.path.expandvars(name) != ""):
+            name = os.path.expandvars(name)
         if set(name) & bad_sym:
             msg = f"Bad name for repo: {name}, contains bad symbols: {''.join(bad_sym)}"
             raise InvalidConfigError(msg)

--- a/tests/data/cleanup_sub.yaml
+++ b/tests/data/cleanup_sub.yaml
@@ -1,0 +1,21 @@
+artifactory-cleanup:
+  server: https://repo.example.com/artifactory
+  # $VAR is auto populated from environment variables
+  user: $ARTIFACTORY_USERNAME
+  password: $ARTIFACTORY_PASSWORD
+
+  policies:
+    - name: Remove all files from repo-name-here older then 7 days
+      rules:
+        - rule: RepoList
+          repos:
+            - "repo-name-here"
+        - rule: DeleteOlderThan
+          days: 7
+
+    - name: Use your own rules!
+      rules:
+        - rule: Repo
+          name: $REPO_NAME
+        - rule: MySimpleRule
+          my_param: "Hello, world!"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,30 @@ def test_dry_mode(capsys, shared_datadir, requests_mock):
         requests_mock.call_count == 4
     ), "Requests: check repository exists, AQL, NO DELETE  - 2 times"
 
+@pytest.mark.usefixtures("requests_repo_name_here")
+def test_dry_mode_with_substitution(capsys, shared_datadir, requests_mock, monkeypatch):
+    monkeypatch.setenv("$REPO_NAME", "repo-name-here")
+    _, code = ArtifactoryCleanupCLI.run(
+        [
+            "ArtifactoryCleanupCLI",
+            "--config",
+            str(shared_datadir / "cleanup_sub.yaml"),
+            "--load-rules",
+            str(shared_datadir / "myrule.py"),
+        ],
+        exit=False,
+    )
+    stdout, stderr = capsys.readouterr()
+    assert code == 0, stdout
+    assert "Verbose MODE" in stdout
+    assert "Destroy MODE" not in stdout
+    assert (
+        "DEBUG - we would delete 'repo-name-here/path/to/file/filename1.json'" in stdout
+    )
+
+    assert (
+        requests_mock.call_count == 4
+    ), "Requests: check repository exists, AQL, NO DELETE  - 2 times"
 
 @pytest.mark.usefixtures("requests_repo_name_here")
 def test_destroy(capsys, shared_datadir, requests_mock):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_dry_mode(capsys, shared_datadir, requests_mock):
         requests_mock.call_count == 4
     ), "Requests: check repository exists, AQL, NO DELETE  - 2 times"
 
+
 @pytest.mark.usefixtures("requests_repo_name_here")
 def test_dry_mode_with_substitution(capsys, shared_datadir, requests_mock, monkeypatch):
     monkeypatch.setenv("$REPO_NAME", "repo-name-here")
@@ -65,6 +66,7 @@ def test_dry_mode_with_substitution(capsys, shared_datadir, requests_mock, monke
     assert (
         requests_mock.call_count == 4
     ), "Requests: check repository exists, AQL, NO DELETE  - 2 times"
+
 
 @pytest.mark.usefixtures("requests_repo_name_here")
 def test_destroy(capsys, shared_datadir, requests_mock):


### PR DESCRIPTION
added functionality to use an environment variable so you don't have to hardcode the repo name into the config yaml
bumped version to 1.0.7