### PR TITLE
refactor manifest.json file into a module constant

### DIFF
--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -12,12 +12,12 @@ from artifactory_cleanup.rules.utils import to_masks
 
 ctx_mgr_block, ctx_mgr_test = get_context_managers()
 
-MANIFEST_FILENAME = "manifest.json"
 
 class RuleForDocker(Rule):
     """
     Parent class for Docker rules
     """
+    MANIFEST_FILENAME = "manifest.json"
 
     def get_docker_images_list(self, docker_repo):
         url = f"/api/docker/{docker_repo}/v2/_catalog"
@@ -42,7 +42,7 @@ class RuleForDocker(Rule):
         """
         for artifact in artifacts:
             # already done it or it's just a folder
-            if "name" not in artifact or artifact["name"] != MANIFEST_FILENAME:
+            if "name" not in artifact or artifact["name"] != self.MANIFEST_FILENAME:
                 continue
 
             artifact["path"], docker_tag = artifact["path"].rsplit("/", 1)
@@ -75,7 +75,7 @@ class RuleForDocker(Rule):
                 artifact["size"] = images_sizes.get(image_key, 0)
 
     def aql_add_filter(self, filters):
-        filters.append({"name": {"$match": MANIFEST_FILENAME}})
+        filters.append({"name": {"$match": self.MANIFEST_FILENAME}})
         return filters
 
     def filter(self, artifacts):

--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -17,6 +17,7 @@ class RuleForDocker(Rule):
     """
     Parent class for Docker rules
     """
+
     MANIFEST_FILENAME = "manifest.json"
 
     def get_docker_images_list(self, docker_repo):

--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -12,6 +12,7 @@ from artifactory_cleanup.rules.utils import to_masks
 
 ctx_mgr_block, ctx_mgr_test = get_context_managers()
 
+MANIFEST_FILENAME = "manifest.json"
 
 class RuleForDocker(Rule):
     """
@@ -36,12 +37,12 @@ class RuleForDocker(Rule):
     def _manifest_to_docker_images(self, artifacts: ArtifactsList):
         """
         Convert manifest.json path to folder path
-        Docker rules get path to "manifest.json" file,
+        Docker rules get path to MANIFEST_FILENAME file,
         in order to remove the whole image we have to "up" one level
         """
         for artifact in artifacts:
             # already done it or it's just a folder
-            if "name" not in artifact or artifact["name"] != "manifest.json":
+            if "name" not in artifact or artifact["name"] != MANIFEST_FILENAME:
                 continue
 
             artifact["path"], docker_tag = artifact["path"].rsplit("/", 1)
@@ -74,7 +75,7 @@ class RuleForDocker(Rule):
                 artifact["size"] = images_sizes.get(image_key, 0)
 
     def aql_add_filter(self, filters):
-        filters.append({"name": {"$match": "manifest.json"}})
+        filters.append({"name": {"$match": MANIFEST_FILENAME}})
         return filters
 
     def filter(self, artifacts):


### PR DESCRIPTION
This is to allow overriding the value (if importing the artifactory_cleanup package from code) to support non-standard manifest file names, e.g. "list.manifest.json" as emitted from 'docker build --cache-to/--cache-from command'

Change inspired by my colleague who worked out how to clean up image caches in the first place.