### PR TITLE
Adds support for semver prefixed with 'v' (e.g., 'v1.2.3')

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ artifactory-cleanup --help
 ```bash
 # Debug - "dry run" mode by default
 # debug run - only print artifacts. it does not delete any artifacts
-artifactory-cleanup 
+artifactory-cleanup
 
 # Debug run only for policytestname.
-artifactory-cleanup --policy-name policytestname 
+artifactory-cleanup --policy-name policytestname
 
 # REMOVE
 # For remove artifacts use --destroy
@@ -317,18 +317,20 @@ policies:
 
 - `KeepLatestNVersionImagesByProperty(count=N, custom_regexp='some-regexp', number_of_digits_in_version=X)` - Leaves N
   Docker images with the same major. `(^\d+\.\d+\.\d+$)` is the default regexp how to determine version which matches semver `1.1.1`. If you
-  need to add minor then set `number_of_digits_in_version` to 2 or if patch then set to 3 (by default we match major, which 1)
-
-- `DeleteDockerImageIfNotContainedInProperties(docker_repo='docker-local', properties_prefix='my-prop', image_prefix=None, full_docker_repo_name=None)`
-    - Remove Docker image, if it is not found in the properties of the artifact repository.
-- `DeleteDockerImageIfNotContainedInPropertiesValue(docker_repo='docker-local', properties_prefix='my-prop', image_prefix=None, full_docker_repo_name=None)`
-    - Remove Docker image, if it is not found in the properties of the artifact repository.
+  need to add minor then set `number_of_digits_in_version` to 2 or if patch then set to 3 (by default we match major, which 1). Semver tags
+  prefixed with `v` are supported by updating the regexp to include (an optional) `v` in the expression (e.g., `(^v?\d+\.\d+\.\d+$)`).
 
 ```yaml
 - rule: KeepLatestNVersionImagesByProperty
   count: 1
   custom_regexp: "[^\\d][\\._]((\\d+\\.)+\\d+)"
 ```
+
+- `DeleteDockerImageIfNotContainedInProperties(docker_repo='docker-local', properties_prefix='my-prop', image_prefix=None, full_docker_repo_name=None)`
+  \- Remove Docker image, if it is not found in the properties of the artifact repository.
+
+- `DeleteDockerImageIfNotContainedInPropertiesValue(docker_repo='docker-local', properties_prefix='my-prop', image_prefix=None, full_docker_repo_name=None)`
+  \- Remove Docker image, if it is not found in the properties of the artifact repository.
 
 ## Filters
 
@@ -338,7 +340,7 @@ policies:
 - rule: IncludePath
   masks: "*production*"
 - rule: IncludePath
-  masks: 
+  masks:
    - "*production*"
    - "*develop*"
 ```
@@ -347,7 +349,7 @@ policies:
 
 ```yaml
 - rule: IncludeFilename
-  masks: 
+  masks:
    - "*production*"
    - "*develop*"
 ```
@@ -356,7 +358,7 @@ policies:
 
 ```yaml
 - rule: ExcludePath
-  masks: 
+  masks:
    - "*production*"
    - "*develop*"
 ```

--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -223,8 +223,12 @@ class KeepLatestNVersionImagesByProperty(RuleForDocker):
         if not match:
             raise ValueError(f"Can not find version in '{artifact}'")
         version_str = match.group()
+        if version_str.startswith("v"):
+            version_str = version_str[1:]
+            return tuple(["v"] + list(map(int, version_str.split("."))))
         version = tuple(map(int, version_str.split(".")))
         return version
+
 
     def filter(self, artifacts):
         artifacts.sort(key=lambda x: x["path"])

--- a/tests/test_rules_docker.py
+++ b/tests/test_rules_docker.py
@@ -63,6 +63,21 @@ class TestKeepLatestNVersionImagesByProperty:
                 "path": "baz/0.1.83",
                 "name": "manifest.json",
             },
+            {
+                "properties": {"docker.manifest": "v0.1.100"},
+                "path": "qux/v0.1.100",
+                "name": "manifest.json",
+            },
+            {
+                "properties": {"docker.manifest": "v0.1.200"},
+                "path": "qux/v0.1.200",
+                "name": "manifest.json",
+            },
+            {
+                "properties": {"docker.manifest": "v0.1.99"},
+                "path": "qux/v0.1.99",
+                "name": "manifest.json",
+            },
         ]
         artifacts = ArtifactsList.from_response(data)
         policy = CleanupPolicy(
@@ -72,6 +87,7 @@ class TestKeepLatestNVersionImagesByProperty:
             KeepLatestNVersionImagesByProperty(
                 count=2,
                 number_of_digits_in_version=1,
+                custom_regexp=r"(^v?\d+\.\d+\.\d+$)",
             ),
         )
         assert policy.filter(artifacts) == [
@@ -91,6 +107,12 @@ class TestKeepLatestNVersionImagesByProperty:
                 "name": "1.1.1",
                 "path": "foobar",
                 "properties": {"docker.manifest": "1.1.1"},
+                "stats": {},
+            },
+            {
+                "name" : "v0.1.99",
+                "path": "qux",
+                "properties": {"docker.manifest": "v0.1.99"},
                 "stats": {},
             },
         ]


### PR DESCRIPTION
Allows using `KeepLatestNVersionImagesByProperty` with semver tags that are prefixed with a 'v'.

* <https://semver.org/#is-v123-a-semantic-version>
* Resolves #92
