### PR TITLE
Fixing typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ policies:
   mask: "*.banned"
 ```
 
-- `PropertyEq`- Delete repository artifacts only with a specific property value (property_name is the name of the
+- `PropertyEq`- Delete repository artifacts only with a specific property value (property_key is the name of the
   parameter, property_value is the value)
 
 ```yaml


### PR DESCRIPTION
Field name in YAML is called `property_key` not `property_name`