### PR TITLE
feat(output): save list of deleted artifacts as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ docker run -v "$(pwd)":/app devopshq/artifactory-cleanup artifactory-cleanup --l
 # Save the table summary in a file
 artifactory-cleanup --output=myfile.txt
 
-# Save the summary in a Json file
+# Save the summary in a json file
 artifactory-cleanup --output=myfile.txt --output-format=json
 
-# Save the summary in a json file and append a list with removed artifacts
+# Save the summary in a json file and append the list of all removed artifacts
 artifactory-cleanup --output=myfile.json --output-format json --output-artifacts
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ artifactory-cleanup --output=myfile.txt
 artifactory-cleanup --output=myfile.txt --output-format=json
 
 # Save the summary in a json file and append a list with removed artifacts
-artifactory-cleanup --output=myfile.json --output-format json-with-artifact-list
+artifactory-cleanup --output=myfile.json --output-format json --output-artifacts
 ```
 
 # Rules

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ artifactory-cleanup --output=myfile.txt
 
 # Save the summary in a Json file
 artifactory-cleanup --output=myfile.txt --output-format=json
+
+# Save the summary in a json file and append a list with removed artifacts
+artifactory-cleanup --output=myfile.json --output-format json-with-artifact-list
 ```
 
 # Rules

--- a/artifactory_cleanup/artifactorycleanup.py
+++ b/artifactory_cleanup/artifactorycleanup.py
@@ -14,7 +14,7 @@ class CleanupSummary:
     policy_name: str
     artifacts_removed: int
     artifacts_size: int
-    removed_artifacts_list: Optional[ArtifactsList] = None
+    removed_artifacts: ArtifactsList
 
 
 class ArtifactoryCleanup:
@@ -26,16 +26,12 @@ class ArtifactoryCleanup:
         today: date,
         ignore_not_found: bool,
         worker_count: int,
-        output_format: str,
-        output_artifacts: bool,
     ):
         self.session = session
         self.policies = policies
         self.destroy = destroy
         self.ignore_not_found = ignore_not_found
         self.worker_count = worker_count
-        self.output_format = output_format
-        self.output_artifacts = output_artifacts,
 
         self._init_policies(today)
 
@@ -81,9 +77,8 @@ class ArtifactoryCleanup:
                     policy_name=policy.name,
                     artifacts_size=artifacts_size,
                     artifacts_removed=len(artifacts_to_remove),
+                    artifacts=artifacts_to_remove
                 )
-                if self.output_format == "json" and self.output_artifacts:
-                    summary.removed_artifacts_list = artifacts_to_remove
                 yield summary
             except KeyError:
                 print("Summary size not defined")

--- a/artifactory_cleanup/artifactorycleanup.py
+++ b/artifactory_cleanup/artifactorycleanup.py
@@ -6,7 +6,7 @@ from attr import dataclass
 from requests import Session
 
 from artifactory_cleanup.errors import ArtifactoryCleanupException
-from artifactory_cleanup.rules.base import CleanupPolicy, ArtifactDict
+from artifactory_cleanup.rules.base import ArtifactsList, CleanupPolicy, ArtifactDict
 
 
 @dataclass
@@ -14,7 +14,7 @@ class CleanupSummary:
     policy_name: str
     artifacts_removed: int
     artifacts_size: int
-    removed_artifacts_list: Optional[dict] = None
+    removed_artifacts_list: Optional[ArtifactsList] = None
 
 
 class ArtifactoryCleanup:
@@ -27,6 +27,7 @@ class ArtifactoryCleanup:
         ignore_not_found: bool,
         worker_count: int,
         output_format: str,
+        output_artifacts: bool,
     ):
         self.session = session
         self.policies = policies
@@ -34,6 +35,7 @@ class ArtifactoryCleanup:
         self.ignore_not_found = ignore_not_found
         self.worker_count = worker_count
         self.output_format = output_format
+        self.output_artifacts = output_artifacts,
 
         self._init_policies(today)
 
@@ -41,7 +43,7 @@ class ArtifactoryCleanup:
         for policy in self.policies:
             policy.init(self.session, today)
 
-    def cleanup(self, block_ctx_mgr, test_ctx_mgr) -> Iterator[CleanupSummary]:
+    def cleanup(self, block_ctx_mgr, test_ctx_mgr) -> Iterator[Optional[CleanupSummary]]:
         for policy in self.policies:
             with block_ctx_mgr(policy.name):
                 # Prepare
@@ -80,7 +82,7 @@ class ArtifactoryCleanup:
                     artifacts_size=artifacts_size,
                     artifacts_removed=len(artifacts_to_remove),
                 )
-                if self.output_format == "json-with-artifact-list":
+                if self.output_format == "json" and self.output_artifacts:
                     summary.removed_artifacts_list = artifacts_to_remove
                 yield summary
             except KeyError:

--- a/artifactory_cleanup/artifactorycleanup.py
+++ b/artifactory_cleanup/artifactorycleanup.py
@@ -77,7 +77,7 @@ class ArtifactoryCleanup:
                     policy_name=policy.name,
                     artifacts_size=artifacts_size,
                     artifacts_removed=len(artifacts_to_remove),
-                    artifacts=artifacts_to_remove
+                    removed_artifacts=artifacts_to_remove
                 )
                 yield summary
             except KeyError:

--- a/artifactory_cleanup/cli.py
+++ b/artifactory_cleanup/cli.py
@@ -201,7 +201,7 @@ class ArtifactoryCleanupCLI(cli.Application):
                 "file_count": summary.artifacts_removed,
                 "size": summary.artifacts_size
             }
-            if summary.removed_artifacts is not None and self._output_artifacts:
+            if self._output_artifacts:
                 policy["removed_artifacts"] = summary.removed_artifacts
             result["policies"].append(policy)
         result["total_size"] = total_size

--- a/artifactory_cleanup/cli.py
+++ b/artifactory_cleanup/cli.py
@@ -96,7 +96,8 @@ class ArtifactoryCleanupCLI(cli.Application):
     )
 
     _output_artifacts = cli.Flag(
-        "--output-artifacts", help="When --output-format is json, append the list of all deleted artifacts to --output.",
+        "--output-artifacts",
+        help="When --output-format is json, append the list of all removed artifacts to output",
         mandatory=False,
         default=False,
     )
@@ -143,13 +144,13 @@ class ArtifactoryCleanupCLI(cli.Application):
         print(self._format_table(result))
 
     def _create_output_file(self, result, filename, format):
-        text = None
+        text = ""
         if format == "table":
             text = self._format_table(result).get_string()
         elif format == "json":
-            text = json.dumps(result)
+            text = json.dumps(result, indent=4)
 
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             file.write(text)
 
     def main(self):
@@ -178,8 +179,6 @@ class ArtifactoryCleanupCLI(cli.Application):
             today=today,
             ignore_not_found=self._ignore_not_found,
             worker_count=self._worker_count,
-            output_format=self._output_format,
-            output_artifacts=self._output_artifacts,
         )
 
         # Filter policies by name
@@ -202,8 +201,8 @@ class ArtifactoryCleanupCLI(cli.Application):
                 "file_count": summary.artifacts_removed,
                 "size": summary.artifacts_size
             }
-            if summary.removed_artifacts_list is not None:
-                policy["artifacts_list"] = summary.removed_artifacts_list
+            if summary.removed_artifacts is not None and self._output_artifacts:
+                policy["removed_artifacts"] = summary.removed_artifacts
             result["policies"].append(policy)
         result["total_size"] = total_size
 

--- a/artifactory_cleanup/cli.py
+++ b/artifactory_cleanup/cli.py
@@ -88,11 +88,17 @@ class ArtifactoryCleanupCLI(cli.Application):
 
     _output_format = cli.SwitchAttr(
         "--output-format",
-        Set("table", "json", "json-with-artifact-list", case_sensitive=False),
+        Set("table", "json", case_sensitive=False),
         help="Choose the output format",
         default="table",
         requires=["--output"],
         mandatory=False,
+    )
+
+    _output_artifacts = cli.Flag(
+        "--output-artifacts", help="When --output-format is json, append the list of all deleted artifacts to --output.",
+        mandatory=False,
+        default=False,
     )
 
     @property
@@ -140,7 +146,7 @@ class ArtifactoryCleanupCLI(cli.Application):
         text = None
         if format == "table":
             text = self._format_table(result).get_string()
-        elif format == "json" or format == "json-with-artifact-list":
+        elif format == "json":
             text = json.dumps(result)
 
         with open(filename, "w") as file:
@@ -173,6 +179,7 @@ class ArtifactoryCleanupCLI(cli.Application):
             ignore_not_found=self._ignore_not_found,
             worker_count=self._worker_count,
             output_format=self._output_format,
+            output_artifacts=self._output_artifacts,
         )
 
         # Filter policies by name


### PR DESCRIPTION
Hello,

I am also interested in the feature from [Pull Request #136](https://github.com/devopshq/artifactory-cleanup/pull/136)
I have rebased the feature branch on master, squashed the commits, and made some modifications.

@roytev  introduced a new option, `--output-artifacts`, which only worked with the specific combination of `--output ... --output-format json --output-artifacts`
As an alternative, I added a new `--output-format` named `json-with-artifact-list`, which I find to be more understandable.
