### PR TITLE
Improve rule KeepLatestNVersionImagesByProperty

### DIFF
--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -263,7 +263,8 @@ class KeepLatestNVersionImagesByProperty(RuleForDocker):
         match = re.match(self.custom_regexp, value)
         if not match:
             raise ValueError(f"Can not find version in '{artifact}'")
-        version_str = match.group()
+        version_str = '.'.join(map(str, match.groups()))
+        version_str = re.sub(r'\.+', '.', version_str)
         if version_str.startswith("v"):
             version_str = version_str[1:]
             return tuple(["v"] + list(map(int, version_str.split("."))))


### PR DESCRIPTION
Allow more custom version when used with corresponding custom regex

e.g.
- version with prefix (uat-1.2.3)
- any other version structure if there is at least an int for major, minor and patch in this order (see added tests)