### PR TITLE
Bump to bookworm image for Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,10 @@ FROM python:3.9.22-slim-bookworm
 # set CERT paths for python libraries, necessary for self-signed certificates
 #  - Requests Library
 #  -> https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
-ENV REQUESTS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 #  - openssl
 #  -> https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_default_verify_paths.html
-ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 COPY . /src
 COPY docker/run.sh /opt/docker/run.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.12-slim-buster
+FROM python:3.9.22-slim-bookworm
 
 # set CERT paths for python libraries, necessary for self-signed certificates
 #  - Requests Library


### PR DESCRIPTION
There are some CVEs currently set in buster that are a bit problematic for some security scans (i.e. CVE-2021-33574). So I would like to propose to bump to the more recent bookworm images that normally should have less security vulnerabilities.

Let me know if you may also want to bump to 3.10, since the GitHub actions is anyway [deploying with 3.10 and not 3.9](https://github.com/devopshq/artifactory-cleanup/blob/master/.github/workflows/release.yml#L22C10-L22C33).

Also, I took the opportunity to fix this legacy syntax:
```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 6)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 9)
```