### PR TITLE
Add multiarch images to Docker rules

### DIFF
--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -19,6 +19,7 @@ class RuleForDocker(Rule):
     """
 
     MANIFEST_FILENAME = "manifest.json"
+    FAT_MANIFEST_FILENAME = "list.manifest.json"
 
     def get_docker_images_list(self, docker_repo):
         url = f"/api/docker/{docker_repo}/v2/_catalog"
@@ -37,13 +38,13 @@ class RuleForDocker(Rule):
 
     def _manifest_to_docker_images(self, artifacts: ArtifactsList):
         """
-        Convert manifest.json path to folder path
-        Docker rules get path to MANIFEST_FILENAME file,
+        Convert manifest.json or list.manifest.json path to folder path
+        Docker rules get path to MANIFEST_FILENAME file or FAT_MANIFEST_FILENAME for multiarch images,
         in order to remove the whole image we have to "up" one level
         """
         for artifact in artifacts:
             # already done it or it's just a folder
-            if "name" not in artifact or artifact["name"] != self.MANIFEST_FILENAME:
+            if "name" not in artifact or artifact["name"] not in [self.MANIFEST_FILENAME, self.FAT_MANIFEST_FILENAME]:
                 continue
 
             artifact["path"], docker_tag = artifact["path"].rsplit("/", 1)
@@ -76,7 +77,7 @@ class RuleForDocker(Rule):
                 artifact["size"] = images_sizes.get(image_key, 0)
 
     def aql_add_filter(self, filters):
-        filters.append({"name": {"$match": self.MANIFEST_FILENAME}})
+        filters.append({'$or': [{'name': {'$match': self.MANIFEST_FILENAME}}, {'name': {'$match': self.FAT_MANIFEST_FILENAME}}]})
         return filters
 
     def filter(self, artifacts):


### PR DESCRIPTION
We need to delete 'parent' manifest for multiarch 

```
                  +----------------------+
                  |  list.manifest.json  |   # Multi-arch manifest list, pointing to all architectures
                  +----------+-----------+
                             |
        -------------------------------------------------
        |                                               |
+-------------------------+                +-------------------------+
|   manifest.json         |                |   manifest.json         |
|   (linux/amd64)         |                |   (linux/arm64/v8)      |
+------------+------------+                +------------+------------+
             |                                          |
   -------------------------                 -------------------------
   |                       |                 |                       |
+-------------+     +------------+     +------------+          +------------+
| sha256_aaa  |     | sha256_bbb |     | sha256_xxx |          | sha256_yyy |
|  Layer blob |     |  Layer blob|     |  Layer blob|          |  Layer blob|
+-------------------+------------+     +------------+----------+------------+


```