### PR TITLE
Fix PropertyEq for multiple properties and improve query performance

### DIFF
--- a/artifactory_cleanup/rules/repo.py
+++ b/artifactory_cleanup/rules/repo.py
@@ -98,10 +98,9 @@ class PropertyEq(Rule):
 
     def aql_add_filter(self, filters):
         filter_ = {
-            "$and": [
-                {"property.key": {"$eq": self.property_key}},
-                {"property.value": {"$eq": self.property_value}},
-            ]
+            f"@{self.property_key}": {
+                "$eq": self.property_value,
+            }
         }
         filters.append(filter_)
         return filters


### PR DESCRIPTION
## What does this PR do?
- fix incorrect behavior of the `PropertyEq` rule when artifacts have multiple properties
- simplify the generated AQL/SQL to improve performance

## Motivation
The current `PropertyEq` implementation checks the property key and value in separate conditions. This can produce false positives when an artifact has multiple properties, because the key and value may match different properties instead of the same one.

By using Artifactory’s [@ property syntax](https://jfrog.com/help/r/jfrog-artifactory-documentation/properties-criteria), the rule ensures the key and value belong to the same property and generates a single condition, improving correctness and performance.

### Example
Rule:
  ```
  - rule: PropertyEq
    property_key: my-test-property
    property_value: 100
  ```
Current SQL (incorrect for multiple properties):
  ```sql
  …
  AND (
      EXISTS (
          SELECT 1
          FROM node_props npsub
          WHERE npsub.node_id = n.node_id
          AND npsub.prop_key = 'my-test-property'
      )
  )
  AND (
      EXISTS (
          SELECT 1
          FROM node_props npsub
          WHERE npsub.node_id = n.node_id
          AND npsub.prop_value = '100'
      )
  )
  …
  ```
New SQL (correct and faster):
  ```sql
  …
  AND (
      EXISTS (
          SELECT 1
          FROM node_props npsub
          WHERE npsub.node_id = n.node_id
          AND npsub.prop_key = 'my-test-property'
          AND npsub.prop_value = '100'
      )
  )
  …
  ```
  
