### PR TITLE
Bump version to 1.0.19

### DIFF
--- a/artifactory_cleanup/__init__.py
+++ b/artifactory_cleanup/__init__.py
@@ -7,4 +7,4 @@ def register(rule):
     registry.register(rule)
 
 
-__version__ = "1.0.18"
+__version__ = "1.0.19"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="artifactory-cleanup",
-    version="1.0.18",
+    version="1.0.19",
     description="Rules and cleanup policies for Artifactory",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR bumps the version to prepare for a new release. Since the last release, several changes have been merged:

- [Add multiarch images to Docker rules](https://github.com/devopshq/artifactory-cleanup/commit/4fff9794d6d35d09c19d63bd4c1f477361f97483)
- [Simplify PropertyEq rule for improved performance](https://github.com/devopshq/artifactory-cleanup/commit/65a9c2f5c71562291b0cda1c722b8da5b445de75)
- [README: rename policy-name to policy](https://github.com/devopshq/artifactory-cleanup/commit/25f3f51dcbc60c985d04a64ef6e42076704dd9e1)

Maintainers can adjust the version number if a minor release (1.1.0) is more appropriate.